### PR TITLE
Patch breaking nested dependency of markupsafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ sqlalchemy==1.3.19
 pylint==2.6.0
 pytype==2020.11.3
 yapf==0.30.0
+
+# Broken dependencies
+markupsafe==2.0.1


### PR DESCRIPTION
Resolves breaking dependency in markupsafe. `soft_unicode` was removed in a newer version

Arises when running
```console
$ sudo make presubmit
```
Traceback
```console
sudo make presubmit
source .venv/bin/activate && python3 presubmit.py
Traceback (most recent call last):
  File "presubmit.py", line 41, in <module>
    from service import automatic_run_experiment
  File "service/automatic_run_experiment.py", line 33, in <module>
    from experiment import run_experiment
  File "experiment/run_experiment.py", line 27, in <module>
    import jinja2
  File ".venv/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File ".venv/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File ".venv/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File ".venv/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe'
```